### PR TITLE
Fix: Disable pull-to-refresh and differentiate piece colors

### DIFF
--- a/src/components/Game/getAnimals.js
+++ b/src/components/Game/getAnimals.js
@@ -8,31 +8,31 @@ export const getAnimals = (gameType) => ({
   lion: {
     image: lion,
     color: "#f8b9bb",
-    skyColor: "#f0a0a2", // Slightly darker pink
+    skyColor: "#f0a0a2",
     moves: ["s**"],
   },
   chick: { 
     image: chick, 
     color: "#ebf2d4", 
-    skyColor: "#d8e0c0", // Slightly darker light yellowish-green
+    skyColor: "#d8e0c0",
     moves: ["stm"] 
   },
   hen: { 
     image: hen, 
     color: "#ebf2d4", 
-    skyColor: "#d8e0c0", // Slightly darker light yellowish-green
+    skyColor: "#d8e0c0",
     moves: ["st*", "sm*", "sbm"] 
   },
   elephant: {
     image: elephant,
     color: "#cdaed0",
-    skyColor: "#b899bc", // Slightly darker lavender
+    skyColor: "#b899bc",
     moves: ["stl", "str", "sbl", "sbr"],
   },
   giraffe: { 
     image: giraffe, 
     color: "#cdaed0", 
-    skyColor: "#b899bc", // Slightly darker lavender
+    skyColor: "#b899bc",
     moves: ["s*m", "sm*"] 
   },
 });

--- a/src/components/Game/getAnimals.js
+++ b/src/components/Game/getAnimals.js
@@ -8,16 +8,33 @@ export const getAnimals = (gameType) => ({
   lion: {
     image: lion,
     color: "#f8b9bb",
+    skyColor: "#f0a0a2", // Slightly darker pink
     moves: ["s**"],
   },
-  chick: { image: chick, color: "#ebf2d4", moves: ["stm"] },
-  hen: { image: hen, color: "#ebf2d4", moves: ["st*", "sm*", "sbm"] },
+  chick: { 
+    image: chick, 
+    color: "#ebf2d4", 
+    skyColor: "#d8e0c0", // Slightly darker light yellowish-green
+    moves: ["stm"] 
+  },
+  hen: { 
+    image: hen, 
+    color: "#ebf2d4", 
+    skyColor: "#d8e0c0", // Slightly darker light yellowish-green
+    moves: ["st*", "sm*", "sbm"] 
+  },
   elephant: {
     image: elephant,
     color: "#cdaed0",
+    skyColor: "#b899bc", // Slightly darker lavender
     moves: ["stl", "str", "sbl", "sbr"],
   },
-  giraffe: { image: giraffe, color: "#cdaed0", moves: ["s*m", "sm*"] },
+  giraffe: { 
+    image: giraffe, 
+    color: "#cdaed0", 
+    skyColor: "#b899bc", // Slightly darker lavender
+    moves: ["s*m", "sm*"] 
+  },
 });
 
 const promotions = {

--- a/src/components/Piece/Piece.js
+++ b/src/components/Piece/Piece.js
@@ -8,7 +8,8 @@ function Piece({ className, type, isSky }) {
   const boardDimensions = useContext(BoardDimensionsContext);
   const animals = useContext(AnimalsContext);
   const [pieceWidth, setPieceWidth] = useState(0);
-  const { color, image, moves } = animals[type];
+  // Destructure skyColor as well
+  const { color, skyColor, image, moves } = animals[type]; 
 
   const measuredPieceRef = useCallback(
     (node) => {
@@ -21,12 +22,15 @@ function Piece({ className, type, isSky }) {
 
   const moveIndicatorSize = Math.ceil(pieceWidth * 0.05);
 
+  // Determine the backgroundColor based on isSky
+  const pieceColor = isSky ? skyColor : color;
+
   return (
     <div
       className={cls(styles.base, className)}
       ref={measuredPieceRef}
       style={{
-        backgroundColor: color || "white",
+        backgroundColor: pieceColor || "white", // Updated color logic
         transform: isSky && "rotate(180deg)",
         backgroundImage: `url(${image})`,
       }}

--- a/src/components/Piece/Piece.js
+++ b/src/components/Piece/Piece.js
@@ -30,7 +30,7 @@ function Piece({ className, type, isSky }) {
       className={cls(styles.base, className)}
       ref={measuredPieceRef}
       style={{
-        backgroundColor: pieceColor || "white", // Updated color logic
+        backgroundColor: pieceColor || "white",
         transform: isSky && "rotate(180deg)",
         backgroundImage: `url(${image})`,
       }}

--- a/src/components/Piece/Piece.js
+++ b/src/components/Piece/Piece.js
@@ -8,7 +8,7 @@ function Piece({ className, type, isSky }) {
   const boardDimensions = useContext(BoardDimensionsContext);
   const animals = useContext(AnimalsContext);
   const [pieceWidth, setPieceWidth] = useState(0);
-  // Destructure skyColor as well
+
   const { color, skyColor, image, moves } = animals[type]; 
 
   const measuredPieceRef = useCallback(

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overscroll-behavior-y: contain; /* Prevent pull-to-refresh */
 }
 
 code {


### PR DESCRIPTION
- I disabled pull-to-refresh on mobile devices by adding 'overscroll-behavior-y: contain' to the body style in index.css.
- I differentiated piece colors for 'sky' (opponent) and 'land' (player) pieces.
  - I added a 'skyColor' property to each animal definition in getAnimals.js, providing a slightly darker shade for opponent pieces.
  - I updated Piece.js to use 'skyColor' when the 'isSky' prop is true.